### PR TITLE
Fix car endpoint after island.is GraphQL schema rename

### DIFF
--- a/src/endpoints/car.test.ts
+++ b/src/endpoints/car.test.ts
@@ -6,11 +6,10 @@ import car from "./car.ts";
 
 const mockCarResponse = {
   data: {
-    getPublicVehicleSearch: {
+    publicVehicleSearch: {
       permno: "ABC12",
       make: "Toyota",
-      model: "Corolla",
-      year: 2020,
+      vehicleCommercialName: "Corolla",
       color: "Blue",
     },
   },
@@ -42,10 +41,10 @@ Deno.test("car - fetches and returns vehicle data", async () => {
 
 Deno.test("car - includes number parameter in API call", async () => {
   const originalFetch = globalThis.fetch;
-  let requestedUrl = "";
+  let requestBody = "";
 
-  globalThis.fetch = (url: string | URL | Request) => {
-    requestedUrl = url.toString();
+  globalThis.fetch = (_url: string | URL | Request, init?: RequestInit) => {
+    requestBody = init?.body as string ?? "";
     return Promise.resolve(
       new Response(JSON.stringify(mockCarResponse), { status: 200 }),
     );
@@ -55,7 +54,7 @@ Deno.test("car - includes number parameter in API call", async () => {
     const req = new Request("http://localhost/x/car/XYZ99");
     await car(req, { number: "XYZ99" });
 
-    assertStringIncludes(requestedUrl, "XYZ99");
+    assertStringIncludes(requestBody, "XYZ99");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/endpoints/car.ts
+++ b/src/endpoints/car.ts
@@ -1,6 +1,30 @@
 import { response } from "../utils.ts";
 // TODO: Implement caching
 
+const VEHICLE_SEARCH_QUERY =
+  `query publicVehicleSearch($input: GetPublicVehicleSearchInput!) {
+  publicVehicleSearch(input: $input) {
+    permno
+    regno
+    vin
+    make
+    vehicleCommercialName
+    color
+    newRegDate
+    firstRegDate
+    vehicleStatus
+    nextVehicleMainInspection
+    co2
+    weightedCo2
+    co2WLTP
+    weightedCo2WLTP
+    massLaden
+    mass
+    co
+    typeNumber
+  }
+}`;
+
 /**
  * Pretty bog standard fetching the data from a existing endpoint and returining whatever it gives us.
  */
@@ -8,13 +32,19 @@ async function car(
   request: Request,
   params: Record<string, string>,
 ): Promise<Response> {
-  const serverResponse = await fetch(
-    `https://island.is/api/graphql?operationName=GetPublicVehicleSearch&variables=%7B%22input%22%3A%7B%22search%22%3A%22${params.number}%22%7D%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22b04f6f91c746425e2b15966df336f47814b94a0642bfbf6fa3ad7bdd8d3c80e5%22%7D%7D`,
-  );
+  const serverResponse = await fetch("https://island.is/api/graphql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "publicVehicleSearch",
+      variables: { input: { search: params.number } },
+      query: VEHICLE_SEARCH_QUERY,
+    }),
+  });
   const json = await serverResponse.json();
   const url = new URL(request.url);
   return response(
-    json.data.getPublicVehicleSearch,
+    json.data.publicVehicleSearch,
     url.searchParams.get("pretty") === "true",
   );
 }


### PR DESCRIPTION
## Summary
- The island.is API renamed `getPublicVehicleSearch` to `publicVehicleSearch`, breaking the car endpoint
- Switched from a URL-encoded persisted query hash (GET) to sending the full GraphQL query via POST, which is more maintainable
- Updated tests to match the new response shape

Fixes #60

## Test plan
- [x] All unit tests pass (`deno test --allow-env`)
- [x] `deno fmt`, `deno lint`, `deno check` all pass
- [x] Manually verified the updated query returns data from island.is
- [ ] Live tests should pass once merged (daily CI will confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)